### PR TITLE
Update README; Correct Docker Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.or
 ## Running
 
 ```
-docker run --rm -it -p 1234:1234 28785:28785/udp ghcr.io/cfoust/sour
+docker run --rm -it -p 1234:1234 -p 28785:28785/udp ghcr.io/cfoust/sour
 ```
 
 You can then access Sour at `http://localhost:1234/` or by connecting in [the desktop client](http://sauerbraten.org/) with `/connect localhost`.


### PR DESCRIPTION
I receive the following error when running the Docker command from the README.

```
└─$ sudo docker run --rm -it -p 1234:1234 28785:28785/udp ghcr.io/cfoust/sour
[sudo] password for christian: 
Unable to find image '28785:28785/udp:latest' locally
```

I received this both on my home server and Linux laptop.

```
Docker version 20.10.11, build dea9396
```

Correction is just specifying the `-p` flag again before the second port mapping.