### PR TITLE
add int64 type conversion to sourdump encode and decode

### DIFF
--- a/pkg/maps/decode.go
+++ b/pkg/maps/decode.go
@@ -19,7 +19,7 @@ func MapToGo(parent worldio.Cube) *Cube {
 	children := make([]*Cube, 0)
 	for i := 0; i < CUBE_FACTOR; i++ {
 		cube := Cube{}
-		member := worldio.CubeArray_getitem(parent, i)
+		member := worldio.CubeArray_getitem(parent, int64(i))
 
 		if member.GetChildren().Swigcptr() != 0 {
 			cube.Children = MapToGo(member.GetChildren()).Children
@@ -28,7 +28,7 @@ func MapToGo(parent worldio.Cube) *Cube {
 		if member.GetExt().Swigcptr() != 0 {
 			ext := member.GetExt()
 			for j := 0; j < 6; j++ {
-				surface := worldio.SurfaceInfoArray_getitem(ext.GetSurfaces(), j)
+				surface := worldio.SurfaceInfoArray_getitem(ext.GetSurfaces(), int64(j))
 				cube.SurfaceInfo[j].Lmid[0] = worldio.UcharArray_getitem(surface.GetLmid(), 0)
 				cube.SurfaceInfo[j].Lmid[1] = worldio.UcharArray_getitem(surface.GetLmid(), 1)
 				cube.SurfaceInfo[j].Verts = surface.GetVerts()
@@ -38,13 +38,13 @@ func MapToGo(parent worldio.Cube) *Cube {
 
 		// edges
 		for j := 0; j < 12; j++ {
-			value := worldio.UcharArray_getitem(member.GetEdges(), j)
+			value := worldio.UcharArray_getitem(member.GetEdges(), int64(j))
 			cube.Edges[j] = value
 		}
 
 		// texture
 		for j := 0; j < 6; j++ {
-			value := worldio.Uint16Array_getitem(member.GetTexture(), j)
+			value := worldio.Uint16Array_getitem(member.GetTexture(), int64(j))
 			cube.Texture[j] = value
 		}
 

--- a/pkg/maps/encode.go
+++ b/pkg/maps/encode.go
@@ -54,7 +54,7 @@ func MapToCXX(cube *Cube) worldio.Cube {
 		cxx.SetMerged(cube.Merged)
 		cxx.SetEscaped(cube.Escaped)
 
-		worldio.CubeArray_setitem(parent, i, cxx)
+		worldio.CubeArray_setitem(parent, int64(i), cxx)
 	}
 
 	return parent


### PR DESCRIPTION
fixes the sourdump go build for me using go version go1.23.2 linux/amd64 which might be more strict on requiring explicit int64 types than go version go1.23.3 linux/amd64 that is used in CI to build sourdump
```
/sour/assets](main)$ bash -x setup
+++ dirname setup
++ cd .
++ pwd
+ SCRIPT_DIR=/home/mpr/git/sourfork/sour/assets
+ cd /home/mpr/git/sourfork/sour/assets
+ set -e
+ mkdir -p cache
+ pip3 list
+ grep cbor2
+ '[' -f sourdump ']'
+ cd ..
+ go build -o assets/sourdump cmd/sourdump/main.go
# github.com/cfoust/sour/pkg/maps
pkg/maps/decode.go:22:47: cannot use i (variable of type int) as int64 value in argument to worldio.CubeArray_getitem
pkg/maps/decode.go:31:68: cannot use j (variable of type int) as int64 value in argument to worldio.SurfaceInfoArray_getitem
pkg/maps/decode.go:41:59: cannot use j (variable of type int) as int64 value in argument to worldio.UcharArray_getitem
pkg/maps/decode.go:47:62: cannot use j (variable of type int) as int64 value in argument to worldio.Uint16Array_getitem
pkg/maps/encode.go:57:37: cannot use i (variable of type int) as int64 value in argument to worldio.CubeArray_setitem```